### PR TITLE
Fix "Passing coroutines is forbidden, use tasks explicitly." error on…

### DIFF
--- a/custom_components/viomise/vacuum.py
+++ b/custom_components/viomise/vacuum.py
@@ -191,7 +191,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         for vacuum in target_vacuums:
             update_coro = vacuum.async_update_ha_state(True)
-            update_tasks.append(update_coro)
+            update_tasks.append(asyncio.create_task(update_coro))
 
         if update_tasks:
             await asyncio.wait(update_tasks)


### PR DESCRIPTION
… zone cleaning

This small PR fixes an error on Zone cleanup, as "Passing coroutines is forbidden, use tasks explicitly." prevents this action. See more in https://github.com/KrzysztofHajdamowicz/home-assistant-vacuum-styj02ym/commit/9e6c4808c5dccfe9f294db882b3fcc3adbd61af7